### PR TITLE
Fix ensureLoadVariants() name mismatch between readme and others

### DIFF
--- a/examples/KHR_materials_variants.html
+++ b/examples/KHR_materials_variants.html
@@ -84,7 +84,7 @@
           saveButton.innerText = 'Save glb';
           saveButton.addEventListener('click', async () => {
             saveButton.disabled = true;
-            await gltf.functions.ensureLoadVariantMaterials(scene);
+            await gltf.functions.ensureLoadVariants(scene);
             exporter.parse(scene, async result => {
               saveArrayBuffer(result, 'scene.glb');
               saveButton.disabled = false;
@@ -95,7 +95,7 @@
           dumpButton.innerText = 'Dump to console';
           dumpButton.addEventListener('click', async () => {
             dumpButton.disabled = true;
-            await gltf.functions.ensureLoadVariantMaterials(scene);
+            await gltf.functions.ensureLoadVariants(scene);
             exporter.parse(scene, result => {
               console.log(result);
               dumpButton.disabled = false;

--- a/exporters/KHR_materials_variants/README.md
+++ b/exporters/KHR_materials_variants/README.md
@@ -10,7 +10,7 @@ import GLTFExporterMaterialsVariantsExtension from 'path_to_three-gltf-extension
 const exporter = new GLTFExporter();
 exporter.register(writer => new GLTFExporterMaterialsVariantsExtension(writer));
 
-gltf.functions.ensureLoadVariantMaterials(scene); // Refer to "ensureLoadVariants()" in the KHR_materials_variants GLTFLoader plugin README
+gltf.functions.ensureLoadVariants(scene); // Refer to "ensureLoadVariants()" in the KHR_materials_variants GLTFLoader plugin README
 exporter.parse(scene, result => {
   ...
 });
@@ -44,4 +44,4 @@ And if `mesh.userData.originalMaterial` is defined as Three.js Material, the plu
 
 * Three.js multi material is not supported (yet)
 * The plugin doesn't verify `.userData` format. it's a user side responsibility.
-* If you want to export the models including variants materials loaded by the `GLTFLoader` KHR_materials_variants plugin, be careful that unloaded materials are not exported. If you want to ensure that all the variant materials will be exported, use `ensureLoadVariantMaterials()` of the loader plugin.
+* If you want to export the models including variants materials loaded by the `GLTFLoader` KHR_materials_variants plugin, be careful that unloaded materials are not exported. If you want to ensure that all the variant materials will be exported, use `ensureLoadVariants()` of the loader plugin.

--- a/loaders/KHR_materials_variants/KHR_materials_variants.js
+++ b/loaders/KHR_materials_variants/KHR_materials_variants.js
@@ -160,7 +160,7 @@ export default class GLTFMaterialsVariantsExtension {
      * @param object {THREE.Object3D}
      * @return {Promise}
      */
-    const ensureLoadVariantMaterials = object => {
+    const ensureLoadVariants = object => {
       const currentMaterial = object.material;
       const variantMaterials = object.userData.variantMaterials;
       const pending = [];
@@ -202,12 +202,12 @@ export default class GLTFMaterialsVariantsExtension {
      * @param doTraverse {boolean} Default is true
      * @return {Promise}
      */
-    gltf.functions.ensureLoadVariantMaterials = (object, doTraverse = true) => {
+    gltf.functions.ensureLoadVariants = (object, doTraverse = true) => {
       const pending = [];
       if (doTraverse) {
-        object.traverse(o => compatibleObject(o) && pending.push(ensureLoadVariantMaterials(o)));
+        object.traverse(o => compatibleObject(o) && pending.push(ensureLoadVariants(o)));
       } else {
-        compatibleObject(object) && pending.push(ensureLoadVariantMaterials(object));
+        compatibleObject(object) && pending.push(ensureLoadVariants(object));
       }
       return Promise.all(pending);
     };

--- a/test/KHR_materials_variants.js
+++ b/test/KHR_materials_variants.js
@@ -139,7 +139,7 @@ export default QUnit.module('KHR_materials_variants', () => {
         });
     });
 
-    QUnit.test('ensureLoadVariantMaterials', assert => {
+    QUnit.test('ensureLoadVariants', assert => {
       const done = assert.async();
       new GLTFLoader()
         .register(parser => new GLTFMaterialsVariantsExtension(parser))
@@ -147,7 +147,7 @@ export default QUnit.module('KHR_materials_variants', () => {
           const variants = gltf.userData.variants;
           const scene = gltf.scene;
 
-          await gltf.functions.ensureLoadVariantMaterials(scene);
+          await gltf.functions.ensureLoadVariants(scene);
 
           let loaded = true;
 


### PR DESCRIPTION
`ensureLoadVariants()` is the correct name, `ensureLoadVariantMaterials()` is wrong.