### PR TITLE
Store other attributes to mesh.geometry in EXT_mesh_gpu_instancing loader plugin

### DIFF
--- a/loaders/EXT_mesh_gpu_instancing/EXT_mesh_gpu_instancing.js
+++ b/loaders/EXT_mesh_gpu_instancing/EXT_mesh_gpu_instancing.js
@@ -27,7 +27,6 @@ export default class GLTFInstancingExtension {
     // @TODO: Can we support InstancedMesh + SkinnedMesh?
     const pending = [];
     const attributes = {};
-    pending.push(this.parser.createNodeMesh(nodeIndex));
     for (const key in attributesDef) {
       pending.push(this.parser.getDependency('accessor', attributesDef[key]).then(accessor => {
         attributes[key] = accessor;
@@ -35,15 +34,21 @@ export default class GLTFInstancingExtension {
       }));
     }
 
+    if (pending.length < 1) {
+      return null;
+    }
+
+    pending.push(this.parser.createNodeMesh(nodeIndex));
+
     return Promise.all(pending).then(results => {
-      const mesh = results[0];
+      const mesh = results.pop();
 
       // @TODO: Fix me. Support Group (= glTF multiple mesh.primitives).
       if (!mesh.isMesh) {
         return mesh;
       }
 
-      const count = results[1].count; // All attribute counts should be same
+      const count = results[0].count; // All attribute counts should be same
 
       // For Working
       const m = mesh.matrix.clone();
@@ -62,8 +67,16 @@ export default class GLTFInstancingExtension {
         if (attributes.SCALE) {
           s.fromBufferAttribute(attributes.SCALE, i);
         }
-        // @TODO: Support _ID and others
         instancedMesh.setMatrixAt(i, m.compose(p, q, s));
+      }
+
+      // We store other attributes to mesh.geometry so far.
+      for (const attributeName in attributes) {
+        if (attributeName !== 'TRANSLATION' &&
+          attributeName !== 'ROTATION' &&
+          attributeName !== 'SCALE') {
+          mesh.geometry.setAttribute(attributeName, attributes[attributeName]);
+        }
       }
 
       // Just in case


### PR DESCRIPTION
Store custom instance attribute into `mesh.geometry` so far in the `EXT_mesh_gpu_instancing` loader plugin.

If `mesh` is shared with other nodes as non-instanced mesh, the custom attributes are unnecessary for them but shouldn't hurt.