### PR TITLE
Add EXT_mesh_gpu_instancing exporter and Readme

### DIFF
--- a/exporters/EXT_mesh_gpu_instancing/EXT_mesh_gpu_instancing_exporter.js
+++ b/exporters/EXT_mesh_gpu_instancing/EXT_mesh_gpu_instancing_exporter.js
@@ -1,0 +1,67 @@
+/**
+ * Mesh GPU Instancing extension
+ *
+ * Specification: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing
+ */
+
+ import {
+	BufferAttribute,
+	Matrix4,
+	Vector3,
+	Quaternion,
+} from 'three';
+
+ export default class GLTFMeshGPUInstancingExtension {
+
+	constructor( writer ) {
+
+		this.writer = writer;
+		this.name = 'EXT_mesh_gpu_instancing';
+
+	}
+
+	writeNode( node, nodeDef ) {
+
+		if(node.constructor.name !== "InstancedMesh") return;
+
+		const writer = this.writer;
+		const extensionsUsed = writer.extensionsUsed;
+		const extensionDef = {};
+		
+		nodeDef.extensions = nodeDef.extensions || {};
+		nodeDef.extensions[ this.name ] = extensionDef;
+
+		let mat = new Matrix4();
+		const pos0 = new Array();
+		const rot0 = new Array();
+		const scl0 = new Array();
+
+		for(let i = 0; i < node.count; i++)
+		{
+			node.getMatrixAt(i, mat);
+			
+			let p = new Vector3();
+			let r = new Quaternion();
+			let s = new Vector3();
+
+			mat.decompose(p,r,s);
+			
+			pos0.push(p.x,p.y,p.z);
+			rot0.push(r.x,r.y,r.z,r.w);
+			scl0.push(s.x,s.y,s.z);
+		};
+
+		const pos = new Float32Array(pos0);
+		const rot = new Float32Array(rot0);
+		const scl = new Float32Array(scl0);
+
+		extensionDef.attributes = {
+			"TRANSLATION" : writer.processAccessor( new BufferAttribute( pos, 3 ) ),
+			"ROTATION" : writer.processAccessor( new BufferAttribute( rot, 4 ) ),
+			"SCALE" : writer.processAccessor( new BufferAttribute( scl, 3 ) ),
+		};
+
+		extensionsUsed[ this.name ] = true;
+
+	}
+}

--- a/exporters/EXT_mesh_gpu_instancing/README.md
+++ b/exporters/EXT_mesh_gpu_instancing/README.md
@@ -1,0 +1,29 @@
+# Three.js GLTFExporter [EXT_mesh_gpu_instancing](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) extension
+
+## How to use
+
+```javascript
+import * as THREE from 'path_to_three.module.js';
+import {GLTFExporter} from 'path_to_GLTFExporter.js';
+import GLTFMeshGPUInstancingExtension from 'path_to_three-gltf-extensions/exporters/EXT_mesh_gpu_instancing/EXT_mesh_gpu_instancing_exporter.js';
+
+const exporter = new GLTFExporter();
+exporter.register(writer => new GLTFMeshGPUInstancingExtension(writer));
+
+exporter.parse(scene, result => {
+  ...
+});
+```
+
+## Compatible Three.js revision
+
+&gt;= r136
+
+## API
+
+The plugin traverses a scene graph and finds valid `InstancedMesh` usages  
+decomposes the instancing matrices and exports them as `EXT_mesh_gpu_instancing` extension into exported glTF content.
+
+## Limitations
+
+* Only pos(3), rot(4), scale(3) matrices (4x4 transform matrices) are supported.


### PR DESCRIPTION
Added an exporter for GPU instancing for a recent project. I think it makes sense to have it here in this wonderful collection :)

I'm sure there must be a faster way to get the instancing matrix data into the right form to save it as attributes; looking forward to feedback on this, definitely "works but probably slow-ish".

I'm also not sure what the minimum required three version would be, so I added the current one.

Example file exported with this from a threejs scene:
[dragons-vs-vikings.zip](https://github.com/takahirox/three-gltf-extensions/files/7908943/dragons-vs-vikings.zip)

![image](https://user-images.githubusercontent.com/2693840/150434025-b4851899-4f06-4bdb-95ce-e0b82d54f5bc.png)

"Dragon" by jeremy [CC-BY] (https://creativecommons.org/licenses/by/3.0/) via Poly Pizza (https://poly.pizza/m/3ZuMS3IRb0C)
"Thor and the Midgard Serpent" [CC-BY] (http://creativecommons.org/licenses/by/4.0/) by Mr. The Rich (https://skfb.ly/69X8V)