### PR TITLE
GLBRangeRequests: No need to reject even if no bin chunk

### DIFF
--- a/loaders/GLB_range_requests/GLB_range_requests.js
+++ b/loaders/GLB_range_requests/GLB_range_requests.js
@@ -117,10 +117,6 @@ export default class GLBRangeRequests {
       offset += length;
     }
 
-    if (result.binChunkOffset === null) {
-      return Promise.reject(new Error('GLBRangeRequests: No BIN chunk so progressive glb loading is not needed.'));
-    }
-
     if (result.jsonContent.extensionsUsed &&
         result.jsonContent.extensionsUsed.indexOf('EXT_meshopt_compression') >= 0) {
       return Promise.reject(new Error('GLBRangeRequests: currently no EXT_meshopt_compression extension support.'));


### PR DESCRIPTION
No bin chunk GLB is valid. And rejects and ask to load the asset in the regular `gltfLoader.load()` on user end is costly.